### PR TITLE
add support for master_lb_flavor

### DIFF
--- a/magnum/drivers/common/templates/lb_api.yaml
+++ b/magnum/drivers/common/templates/lb_api.yaml
@@ -36,6 +36,7 @@ resources:
     type: Magnum::Optional::Neutron::LBaaS::LoadBalancer
     properties:
       vip_subnet: {get_param: fixed_subnet}
+      flavor: {get_param: master_lb_flavor}
 
   listener:
     condition: allowed_cidrs_disabled

--- a/magnum/drivers/common/templates/lb_etcd.yaml
+++ b/magnum/drivers/common/templates/lb_etcd.yaml
@@ -34,6 +34,7 @@ resources:
     type: Magnum::Optional::Neutron::LBaaS::LoadBalancer
     properties:
       vip_subnet: {get_param: fixed_subnet}
+      flavor: {get_param: master_lb_flavor}
 
   listener:
     condition: allowed_cidrs_disabled

--- a/magnum/drivers/heat/k8s_template_def.py
+++ b/magnum/drivers/heat/k8s_template_def.py
@@ -257,7 +257,8 @@ class K8sTemplateDefinition(template_def.BaseTemplateDefinition):
                       'kubecontroller_options',
                       'kubescheduler_options',
                       'influx_grafana_dashboard_enabled',
-                      'master_lb_allowed_cidrs']
+                      'master_lb_allowed_cidrs',
+                      'master_lb_flavor']
 
         labels = self._get_relevant_labels(cluster, kwargs)
 

--- a/magnum/service/periodic.py
+++ b/magnum/service/periodic.py
@@ -113,12 +113,16 @@ class ClusterHealthUpdateJob(object):
             # UNKNOWN if Magnum failed to pull data from the cluster? Because
             # that basically means the k8s API doesn't work at that moment.
             return
-
+        old_status = self.cluster.health_status
         if monitor.data.get('health_status'):
             self.cluster.health_status = monitor.data.get('health_status')
             self.cluster.health_status_reason = monitor.data.get(
                 'health_status_reason')
             self.cluster.save()
+        if old_status != self.cluster.health_status:
+            conductor_utils.notify_about_cluster_operation(
+                self.ctx, taxonomy.ACTION_UPDATE,
+                taxonomy.OUTCOME_SUCCESS, self.cluster)
 
     def update_health_status(self):
         LOG.debug("Updating health status for cluster %s", self.cluster.id)


### PR DESCRIPTION
Heat supports Octavia load balancer flavors since Ussuri.
A user can control the load balancer flavor through the
master_lb_flavor property.

Change-Id: I6607664ad82d7394023b2712ac5ae2d70f8515a3